### PR TITLE
More UI Bugs Fixed

### DIFF
--- a/Development/Component/share/mpq/ydwe/action.txt
+++ b/Development/Component/share/mpq/ydwe/action.txt
@@ -2854,6 +2854,7 @@ default = "0"
 [[.args]]
 type = real
 default = "0"
+min = 0
 
 [YDWEScriptActFaceReset]
 title = "重置单位身体朝向<Anitarf制作>"

--- a/Development/Component/share/mpq/ydwe/call.txt
+++ b/Development/Component/share/mpq/ydwe/call.txt
@@ -2864,21 +2864,21 @@ type = real
 default = "0"
 [[.args]]
 type = real
-default = "0"
+default = "1024"
 min = 0.01
 [[.args]]
 type = real
-default = "0"
+default = "-96"
 [[.args]]
 type = real
-default = "1024"
+default = "96"
 [[.args]]
 type = integer
-default = "-96"
+default = "4000"
 min = 1
 [[.args]]
 type = integer
-default = "96"
+default = "100"
 min = 1
 
 [DialogAddButton]


### PR DESCRIPTION
几个旧版UI的YDWE自带函数的_Limits都有奇怪的问题
比如中间多一组空的，后面多一组空的之类的。。。
唉参数这么多数错了也正常
（表示做的UI编辑器读官方UI都给用户报一堆错很蛋疼啊）
还有几个_Defaults多参数的好像新版都没问题就不管了

List:
TriggerActions "YDWETimerPatternRushSlide" ("_", "_", "0", "360", "0", "_", "0.01", "_", "0.01", "_", "0", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_")
TriggerActions "YDWEScriptActFace" ("0", "_", "1", "_", "1", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "_", "0", "_")
TriggerCalls "TerrainDeformRandom" ("0", "0", "0", "0", "1024", "-96", "96", "4000", "100")
