### PR TITLE
 紧急修复”伤害事件排泄机制“的BUG

### DIFF
--- a/Development/Component/ui/ydwe/jass/YDWETriggerEvent.j
+++ b/Development/Component/ui/ydwe/jass/YDWETriggerEvent.j
@@ -50,11 +50,14 @@ function YDWEAnyUnitDamagedFilter takes nothing returns boolean
     return false
 endfunction
 
-function YDWEAnyUnitDamagedEnumUnit takes nothing returns nothing   
+function YDWEAnyUnitDamagedEnumUnit takes nothing returns nothing
     local group g = CreateGroup()
-    call GroupEnumUnitsInRect(g, GetWorldBounds(), Condition(function YDWEAnyUnitDamagedFilter))
+    local rect world = GetWorldBounds()
+    call GroupEnumUnitsInRect(g, world, Condition(function YDWEAnyUnitDamagedFilter))
     call DestroyGroup(g)
+    call RemoveRect(world)
     set g = null
+    set world = null
 endfunction
 
 function YDWEAnyUnitDamagedRegistTriggerUnitEnter takes nothing returns nothing

--- a/Development/Component/ui/ydwe/jass/YDWETriggerEvent.j
+++ b/Development/Component/ui/ydwe/jass/YDWETriggerEvent.j
@@ -52,21 +52,26 @@ endfunction
 
 function YDWEAnyUnitDamagedEnumUnit takes nothing returns nothing
     local group g = CreateGroup()
-    local rect world = GetWorldBounds()
-    call GroupEnumUnitsInRect(g, world, Condition(function YDWEAnyUnitDamagedFilter))
+    local integer i = 0
+    loop
+        call GroupEnumUnitsOfPlayer(g, Player(i), Condition(function YDWEAnyUnitDamagedFilter))
+        set i = i + 1
+        exitwhen i >= bj_MAX_PLAYER_SLOTS
+    endloop
     call DestroyGroup(g)
-    call RemoveRect(world)
     set g = null
-    set world = null
 endfunction
 
 function YDWEAnyUnitDamagedRegistTriggerUnitEnter takes nothing returns nothing
     local trigger t = CreateTrigger()
     local region  r = CreateRegion()
-    call RegionAddRect(r, GetWorldBounds())
+    local rect world = GetWorldBounds()
+    call RegionAddRect(r, world)
     call TriggerRegisterEnterRegion(t, r, Condition(function YDWEAnyUnitDamagedFilter))
-    set r = null
+    call RemoveRect(world)
     set t = null
+    set r = null
+    set world = null
 endfunction
 
 // 将 yd_DamageEventTrigger 移入销毁队列, 从而排泄触发器事件


### PR DESCRIPTION
修正严重漏洞：伤害事件重置时，没有为"被隐藏的单位"注册事件
修正了：一个矩形区域的泄露